### PR TITLE
URL Cleanup

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -149,7 +149,7 @@ To integrate Spring XD with Pivotal Hadoop for Cloud Foundry:
 
 Cloud Foundry can forward the runtime logs to external applications, such as Papertrail or Splunk, to help you troubleshoot issues. For more information about configuring logs, see the following topics:
 
-* [Using Third-Party Log Management Services] (http://docs.pivotal.io/pivotalcf/devguide/services/log-management.html)
-* [Configuring Selected Third-Party Management Services] (http://docs.pivotal.io/pivotalcf/devguide/services/log-management-thirdparty-svc.html)
-* [Integrating Cloud Foundry with Splunk](http://docs.pivotal.io/pivotalcf/devguide/services/integrate-splunk.html)
+* [Using Third-Party Log Management Services] (https://docs.pivotal.io/pivotalcf/devguide/services/log-management.html)
+* [Configuring Selected Third-Party Management Services] (https://docs.pivotal.io/pivotalcf/devguide/services/log-management-thirdparty-svc.html)
+* [Integrating Cloud Foundry with Splunk](https://docs.pivotal.io/pivotalcf/devguide/services/integrate-splunk.html)
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.pivotal.io/pivotalcf/devguide/services/integrate-splunk.html with 1 occurrences migrated to:  
  https://docs.pivotal.io/pivotalcf/devguide/services/integrate-splunk.html ([https](https://docs.pivotal.io/pivotalcf/devguide/services/integrate-splunk.html) result 301).
* http://docs.pivotal.io/pivotalcf/devguide/services/log-management-thirdparty-svc.html with 1 occurrences migrated to:  
  https://docs.pivotal.io/pivotalcf/devguide/services/log-management-thirdparty-svc.html ([https](https://docs.pivotal.io/pivotalcf/devguide/services/log-management-thirdparty-svc.html) result 301).
* http://docs.pivotal.io/pivotalcf/devguide/services/log-management.html with 1 occurrences migrated to:  
  https://docs.pivotal.io/pivotalcf/devguide/services/log-management.html ([https](https://docs.pivotal.io/pivotalcf/devguide/services/log-management.html) result 301).